### PR TITLE
Added 1.16 compatiblity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>com.github.arboriginal</groupId>
     <artifactId>Chair</artifactId>
-    <version>1.4</version>
+    <version>1.5</version>
 
     <developers>
         <developer>

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -44,7 +44,11 @@ allowedBlocks:
 - SPRUCE_STAIRS
 - STONE_BRICK_STAIRS
 - STONE_STAIRS
-
+- CRIMSON_STAIRS
+- WARPED_STAIRS
+- BLACKSTONE_STAIRS
+- POLISHED_BLACKSTONE_STAIRS
+- POLISHED_BLACKSTONE_BRICK_STAIRS
 # Advanced: Adjust heights of sit position on some blocks (it was hardcoded in previous plugin version)
 # Those default values works on Spigot / Paper 1.15.2 (actually paper 121 to be precise).
 heightAdjustments:


### PR DESCRIPTION
Only changed the `config.yml` a little, to support the new stairs of MC Java Edition 1.16.
Updates pom.xml as well to 1.5

I did test it in 1.16... But idk if the config will make any problems if the plugins will be used on servers beneath 1.16.